### PR TITLE
Add the filter param to the automatickeParovani method

### DIFF
--- a/src/FlexiPeeHP/Banka.php
+++ b/src/FlexiPeeHP/Banka.php
@@ -44,12 +44,14 @@ class Banka extends FlexiBeeRW
      * @link https://demo.flexibee.eu/devdoc/parovani-plateb Interní dokumentace
      * 
      * @param boolean $advanced Use Advanced matching method ?
+     * @param string $filter Filter bank records before pairing ?
      * 
      * @return boolean
      */
-    public function automatickeParovani($advanced = false)
+    public function automatickeParovani($advanced = false, $filter = null)
     {
-        $this->performRequest('automaticke-parovani'.($advanced ? '-pokrocile' : '' ), 'PUT');
+        $filterUrl = $filter === null ? "" : rtrim($filter, '/') . '/';
+        $this->performRequest($filterUrl . 'automaticke-parovani'.($advanced ? '-pokrocile' : '' ), 'PUT');
         return $this->lastResponseCode == 200;
     }
 }

--- a/src/FlexiPeeHP/Banka.php
+++ b/src/FlexiPeeHP/Banka.php
@@ -38,7 +38,7 @@ class Banka extends FlexiBeeRW
     }
 
     /**
-     * Start invoice authomatic matching process ( it take longer time )
+     * Start invoice automatic matching process ( it takes longer time )
      * Spustí proces automatického párování plateb. ( trvá delší dobu )
      *
      * @link https://demo.flexibee.eu/devdoc/parovani-plateb Interní dokumentace


### PR DESCRIPTION
It allows to filter bank records which should be paired automatically. We would like to use it to pair just one bank account.

I have discussed this with Flexibee support. Filtering is possible despite it's not exactly written in the documention. I have also tested if it works.

E.g.: https://company.flexibee.eu/c/company/banka/(banka='code:BANK ACCOUNT 1')/automaticke-parovani

We are still using version 1.X, so it would be nice to have this feature also in 1.X branch. Thanks.