### PR TITLE
Fix compatibility with PHP 7.4

### DIFF
--- a/src/FlexiPeeHP/FlexiBeeRO.php
+++ b/src/FlexiPeeHP/FlexiBeeRO.php
@@ -1958,7 +1958,7 @@ class FlexiBeeRO extends \Ease\Sand
     public function getRecordID()
     {
         $id = $this->getDataValue('id');
-        return is_null($id) ? null : is_numeric($id) ? intval($id) : $id;
+        return is_null($id) ? null : (is_numeric($id) ? intval($id) : $id);
     }
 
     /**


### PR DESCRIPTION
Deprecated: Unparenthesized `a ? b : c ? d : e` is deprecated. Use either `(a ? b : c) ? d : e` or `a ? b : (c ? d : e)`