### PR TITLE
Fix compatibility with PHP 7.4

### DIFF
--- a/src/FlexiPeeHP/FlexiBeeRO.php
+++ b/src/FlexiPeeHP/FlexiBeeRO.php
@@ -2284,8 +2284,7 @@ class FlexiBeeRO extends \Ease\Sand
         $columnsInfo = $this->getColumnsInfo(empty($evidence) ? $this->getEvidence()
                 : $evidence);
         return (empty($column) || empty($columnsInfo) || !is_array($columnsInfo))
-                ? null : array_key_exists($column, $columnsInfo) ? $columnsInfo[$column]
-                : null;
+                ? null : (array_key_exists($column, $columnsInfo) ? $columnsInfo[$column] : null);
     }
 
     /**


### PR DESCRIPTION
Deprecated: Unparenthesized `a ? b : c ? d : e` is deprecated. Use either `(a ? b : c) ? d : e` or `a ? b : (c ? d : e)`

Sorry that I haven't solved this in the previous PR.